### PR TITLE
Add [assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")] to AssemblyInfo.cs

### DIFF
--- a/Examples/IGBarcode/Properties/AssemblyInfo.cs
+++ b/Examples/IGBarcode/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGBarcode")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGBarcodeReader/Properties/AssemblyInfo.cs
+++ b/Examples/IGBarcodeReader/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGBarcodeReader")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGBulletGraph/Properties/AssemblyInfo.cs
+++ b/Examples/IGBulletGraph/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Samples Project Templates")]
@@ -17,8 +17,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGBulletGraph/Properties/AssemblyInfo.cs
+++ b/Examples/IGBulletGraph/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner

--- a/Examples/IGBusyIndicator/Properties/AssemblyInfo.cs
+++ b/Examples/IGBusyIndicator/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGBusyIndicator")]
@@ -17,8 +17,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGBusyIndicator/Properties/AssemblyInfo.cs
+++ b/Examples/IGBusyIndicator/Properties/AssemblyInfo.cs
@@ -17,8 +17,6 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
-
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/Examples/IGCalculationManager/Properties/AssemblyInfo.cs
+++ b/Examples/IGCalculationManager/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGCalculationManager")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGCalendar/Properties/AssemblyInfo.cs
+++ b/Examples/IGCalendar/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGCalendar")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGCarouselListBox/Properties/AssemblyInfo.cs
+++ b/Examples/IGCarouselListBox/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGCarouselListBox")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGCarouselPanel/Properties/AssemblyInfo.cs
+++ b/Examples/IGCarouselPanel/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGCarouselPanel")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGColorPicker/Properties/AssemblyInfo.cs
+++ b/Examples/IGColorPicker/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGColorPicker")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGComboEditor/Properties/AssemblyInfo.cs
+++ b/Examples/IGComboEditor/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGComboEditor")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGCompression/Properties/AssemblyInfo.cs
+++ b/Examples/IGCompression/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGCompression.SL")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGContextMenu/Properties/AssemblyInfo.cs
+++ b/Examples/IGContextMenu/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGContextMenu")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGDataCards/Properties/AssemblyInfo.cs
+++ b/Examples/IGDataCards/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGDataCards")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGDataCarousel/Properties/AssemblyInfo.cs
+++ b/Examples/IGDataCarousel/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGDataCarousel")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGDataChart/Properties/AssemblyInfo.cs
+++ b/Examples/IGDataChart/Properties/AssemblyInfo.cs
@@ -16,8 +16,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGDataGrid/Properties/AssemblyInfo.cs
+++ b/Examples/IGDataGrid/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGDataGrid")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGDataPieChart/Properties/AssemblyInfo.cs
+++ b/Examples/IGDataPieChart/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGDataPieChart")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGDataPresenter/Properties/AssemblyInfo.cs
+++ b/Examples/IGDataPresenter/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGDataPresenter")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGDataTree/Properties/AssemblyInfo.cs
+++ b/Examples/IGDataTree/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGDataTree")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGDiagram/Properties/AssemblyInfo.cs
+++ b/Examples/IGDiagram/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGDiagram")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGDialogWindow/Properties/AssemblyInfo.cs
+++ b/Examples/IGDialogWindow/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGDialogWindow")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGDockManager/Properties/AssemblyInfo.cs
+++ b/Examples/IGDockManager/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGDockManager")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGDoughnutChart/Properties/AssemblyInfo.cs
+++ b/Examples/IGDoughnutChart/Properties/AssemblyInfo.cs
@@ -16,15 +16,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGDragDropFramework/Properties/AssemblyInfo.cs
+++ b/Examples/IGDragDropFramework/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGDragDropFramework")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGEditors/Properties/AssemblyInfo.cs
+++ b/Examples/IGEditors/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGEditors")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGExcel/Properties/AssemblyInfo.cs
+++ b/Examples/IGExcel/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGExcel")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGFormulaEditor/Properties/AssemblyInfo.cs
+++ b/Examples/IGFormulaEditor/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGFormulaEditor")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGFunnelChart/Properties/AssemblyInfo.cs
+++ b/Examples/IGFunnelChart/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGFunnelChart")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGGantt/Properties/AssemblyInfo.cs
+++ b/Examples/IGGantt/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGGantt")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGGeographicMap/Properties/AssemblyInfo.cs
+++ b/Examples/IGGeographicMap/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGGeographicMap")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGGrid/Properties/AssemblyInfo.cs
+++ b/Examples/IGGrid/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Security;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGGrid")]
@@ -19,8 +19,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGHtmlViewer/Properties/AssemblyInfo.cs
+++ b/Examples/IGHtmlViewer/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGHtmlViewer")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGInputs/Properties/AssemblyInfo.cs
+++ b/Examples/IGInputs/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGInputs")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGLinearGauge/Properties/AssemblyInfo.cs
+++ b/Examples/IGLinearGauge/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Samples Project Templates")]
@@ -17,8 +17,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGLinearGauge/Properties/AssemblyInfo.cs
+++ b/Examples/IGLinearGauge/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner

--- a/Examples/IGMap/Properties/AssemblyInfo.cs
+++ b/Examples/IGMap/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGMap")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGMath/Properties/AssemblyInfo.cs
+++ b/Examples/IGMath/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGMath")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGMenu/Properties/AssemblyInfo.cs
+++ b/Examples/IGMenu/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGMenu")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGMonthCalendar/Properties/AssemblyInfo.cs
+++ b/Examples/IGMonthCalendar/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGMonthCalendar")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGMultiColumnComboEditor/Properties/AssemblyInfo.cs
+++ b/Examples/IGMultiColumnComboEditor/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGMultiColumnComboEditor")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGNetworkNode/Properties/AssemblyInfo.cs
+++ b/Examples/IGNetworkNode/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGNetworkNode")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGOldBulletGraph/Properties/AssemblyInfo.cs
+++ b/Examples/IGOldBulletGraph/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGBulletGraph")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGOrgChart/Properties/AssemblyInfo.cs
+++ b/Examples/IGOrgChart/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGOrgChart")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGOutlookBar/Properties/AssemblyInfo.cs
+++ b/Examples/IGOutlookBar/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGOutlookBar")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGPersistenceFramework/Properties/AssemblyInfo.cs
+++ b/Examples/IGPersistenceFramework/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGPersistenceFramework")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGPieChart/Properties/AssemblyInfo.cs
+++ b/Examples/IGPieChart/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGPieChart")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGPivotGrid/Properties/AssemblyInfo.cs
+++ b/Examples/IGPivotGrid/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGPivotGrid")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGPropertyGrid/Properties/AssemblyInfo.cs
+++ b/Examples/IGPropertyGrid/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGPropertyGrid")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGRadialGauge/Properties/AssemblyInfo.cs
+++ b/Examples/IGRadialGauge/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Security;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGRadialGauge")]
@@ -19,8 +19,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGRadialMenu/Properties/AssemblyInfo.cs
+++ b/Examples/IGRadialMenu/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGRadialMenu")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGReporting/Properties/AssemblyInfo.cs
+++ b/Examples/IGReporting/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGReporting")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGResourceWasher/Properties/AssemblyInfo.cs
+++ b/Examples/IGResourceWasher/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGResourceWasher")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGRibbon/Properties/AssemblyInfo.cs
+++ b/Examples/IGRibbon/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGRibbon")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGRichTextEditor/Properties/AssemblyInfo.cs
+++ b/Examples/IGRichTextEditor/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGRichTextEditor")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGSchedule/Properties/AssemblyInfo.cs
+++ b/Examples/IGSchedule/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGSchedule")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGSlider/Properties/AssemblyInfo.cs
+++ b/Examples/IGSlider/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGSlider")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGSparkline/Properties/AssemblyInfo.cs
+++ b/Examples/IGSparkline/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGSparkline")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGSpellChecker/Properties/AssemblyInfo.cs
+++ b/Examples/IGSpellChecker/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGSpellChecker")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGSpreadsheet/Properties/AssemblyInfo.cs
+++ b/Examples/IGSpreadsheet/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGSpreadsheet")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGSurfaceChart/Properties/AssemblyInfo.cs
+++ b/Examples/IGSurfaceChart/Properties/AssemblyInfo.cs
@@ -16,8 +16,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGSyntaxEditor/Properties/AssemblyInfo.cs
+++ b/Examples/IGSyntaxEditor/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGSyntaxEditor")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGSyntaxParsingEngine/Properties/AssemblyInfo.cs
+++ b/Examples/IGSyntaxParsingEngine/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGSyntaxParsingEngine")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGTabControl/Properties/AssemblyInfo.cs
+++ b/Examples/IGTabControl/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGTabControl")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGTagCloud/Properties/AssemblyInfo.cs
+++ b/Examples/IGTagCloud/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGTagCloud")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGThemeManager/Properties/AssemblyInfo.cs
+++ b/Examples/IGThemeManager/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGThemeManager")]
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -26,12 +26,14 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
+
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]

--- a/Examples/IGTileManager/Properties/AssemblyInfo.cs
+++ b/Examples/IGTileManager/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGTileManager")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGTimeline/Properties/AssemblyInfo.cs
+++ b/Examples/IGTimeline/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGTimeline")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGToolbar/Properties/AssemblyInfo.cs
+++ b/Examples/IGToolbar/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Windows.Markup;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGToolbar")]
@@ -19,8 +19,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGTree/Properties/AssemblyInfo.cs
+++ b/Examples/IGTree/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGTree")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGTreeGrid/Properties/AssemblyInfo.cs
+++ b/Examples/IGTreeGrid/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGTreeGrid")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGTreemap/Properties/AssemblyInfo.cs
+++ b/Examples/IGTreemap/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Windows.Markup;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGTreemap")]
@@ -19,8 +19,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGUndoRedoFramework/Properties/AssemblyInfo.cs
+++ b/Examples/IGUndoRedoFramework/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGUndoRedoFramework")]
@@ -19,15 +19,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGVirtualCollection/Properties/AssemblyInfo.cs
+++ b/Examples/IGVirtualCollection/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGVirtualCollection")]
@@ -16,15 +16,17 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e714cdbc-060d-4f9f-a0f3-10a033f40e2a")]
 
-//In order to begin building localizable applications, set 
+//In order to begin building localizable applications, set
 //<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
 //inside a <PropertyGroup>.  For example, if you are using US english
 //in your source files, set the <UICulture> to en-US.  Then uncomment

--- a/Examples/IGWord/Properties/AssemblyInfo.cs
+++ b/Examples/IGWord/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGWord")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/IGZoombar/Properties/AssemblyInfo.cs
+++ b/Examples/IGZoombar/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("IGZoombar")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/Infragistics.Samples.Assets/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.Samples.Assets/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Markup;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Infragistics.Samples.Assets")]
@@ -17,8 +17,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/Infragistics.Samples.Assets/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.Samples.Assets/Properties/AssemblyInfo.cs
@@ -17,8 +17,6 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
-
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/Examples/Infragistics.Samples.Framework/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.Samples.Framework/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Windows;
 using System.Windows.Markup;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Infragistics.Samples.Framework")]
@@ -18,20 +18,22 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("67450b00-cca4-46e2-8235-97d4b764d294")]
- 
+
 
 [assembly: XmlnsPrefix("http://schemas.infragistics.com/xaml/samples", "igSamples")]
 [assembly: XmlnsDefinition("http://schemas.infragistics.com/xaml/samples", "Infragistics.Samples.Framework")]
 //[assembly: XmlnsDefinition("http://schemas.infragistics.com/xaml/samples", "Infragistics.Samples.Framework.Controls")]
- 
-     
+
+
 //[assembly: AllowPartiallyTrustedCallers()]
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
@@ -40,4 +42,4 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
     ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
     //(used if a resource is not found in the page,
     // app, or any theme specific resource dictionaries)
-)] 
+)]

--- a/Examples/Infragistics.Samples.Framework/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.Samples.Framework/Properties/AssemblyInfo.cs
@@ -18,8 +18,6 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
-
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/Examples/Infragistics.Samples.Services/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.Samples.Services/Properties/AssemblyInfo.cs
@@ -17,8 +17,6 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
-
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/Examples/Infragistics.Samples.Services/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.Samples.Services/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 using System.Windows.Markup;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Infragistics.Samples.Services")]
@@ -17,8 +17,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/Infragistics.Samples.Shared/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.Samples.Shared/Properties/AssemblyInfo.cs
@@ -18,8 +18,6 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
-
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.

--- a/Examples/Infragistics.Samples.Shared/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.Samples.Shared/Properties/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Windows;
 using System.Windows.Markup;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Infragistics.Samples.Shared")]
@@ -18,8 +18,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -28,7 +30,7 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
 //#if WINDOWS_PHONE
 [assembly: System.Resources.NeutralResourcesLanguage("en")]
- 
+
 //[assembly: AllowPartiallyTrustedCallers()]
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located

--- a/Examples/Infragistics.SamplesBrowser.WPF/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.SamplesBrowser.WPF/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Infragistics.SamplesBrowser")]
@@ -17,8 +17,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -26,11 +28,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
 [assembly: ThemeInfo(
     ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
-    //(used if a resource is not found in the page, 
+    //(used if a resource is not found in the page,
     // or application resource dictionaries)
     ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
-    //(used if a resource is not found in the page, 
+    //(used if a resource is not found in the page,
     // app, or any theme specific resource dictionaries)
 )]
 
- 

--- a/Examples/Infragistics.SamplesBrowser.WPF/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.SamplesBrowser.WPF/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner

--- a/Examples/Infragistics.Templates.Framework/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.Templates.Framework/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle(AssemblyDesigner.AssemblyProductPrefix + "Templates.Framework")]
@@ -16,12 +16,13 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("85f214b7-d021-444b-90b2-aa47b91019ff")]
 
- 

--- a/Examples/Infragistics.Templates.SamplesItems/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.Templates.SamplesItems/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Samples Item Templates")]
@@ -17,11 +17,13 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("066d6ddf-82bc-4fc0-9fa8-3a1995371baa")]
- 
+

--- a/Examples/Infragistics.Templates.SamplesPackage/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.Templates.SamplesPackage/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle(AssemblyDesigner.AssemblyProductPrefix + "Templates.SamplesPackage")]
@@ -16,9 +16,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
- 

--- a/Examples/Infragistics.Templates.SamplesProjects/AssemblyInfo.cs
+++ b/Examples/Infragistics.Templates.SamplesProjects/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using Infragistics.Samples.Core;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("$projectname$")]
@@ -18,8 +18,10 @@ using System.Windows;
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/Examples/Infragistics.Templates.SamplesProjects/Properties/AssemblyInfo.cs
+++ b/Examples/Infragistics.Templates.SamplesProjects/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using Infragistics.Samples.Core;        // provides AssemblyDesigner
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Samples Project Templates")]
@@ -17,8 +17,10 @@ using Infragistics.Samples.Core;        // provides AssemblyDesigner
 [assembly: AssemblyVersion(AssemblyDesigner.AssemblyVersion)]
 [assembly: AssemblyFileVersion(AssemblyDesigner.AssemblyVersion)]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+[assembly: InternalsVisibleTo("Infragistics.SamplesBrowser")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 


### PR DESCRIPTION
In terms of avoiding an error even if .Designer.cs code generation is re-executed from .resx. 