### PR TITLE
IGDataChart: demonstrate new MarkerSize in existing Marker Types sample and add Checkmark option

### DIFF
--- a/Examples/IGDataChart/Samples/Display/Markers/BubbleMarkers.xaml
+++ b/Examples/IGDataChart/Samples/Display/Markers/BubbleMarkers.xaml
@@ -228,6 +228,7 @@
                     <ComboBoxItem Tag="Tetragram" Content="{Binding XWDC_MarkerType_Tetragram, Source={StaticResource Strings}}" />
                     <ComboBoxItem Tag="Pentagram" Content="{Binding XWDC_MarkerType_Pentagram, Source={StaticResource Strings}}" />
                     <ComboBoxItem Tag="Hexagram" Content="{Binding XWDC_MarkerType_Hexagram, Source={StaticResource Strings}}" />
+                    <ComboBoxItem Tag="Checkmark" Content="Checkmark" />
                     <ComboBoxItem Tag="Automatic" Content="{Binding XWDC_MarkerType_Automatic, Source={StaticResource Strings}}" />
                     <ComboBoxItem Tag="None" Content="{Binding XWDC_MarkerType_None, Source={StaticResource Strings}}" />
                 </ComboBox>

--- a/Examples/IGDataChart/Samples/Display/Markers/MarkerTypes.xaml
+++ b/Examples/IGDataChart/Samples/Display/Markers/MarkerTypes.xaml
@@ -115,6 +115,7 @@
                     <ComboBoxItem Tag="Tetragram" Content="{Binding XWDC_MarkerType_Tetragram, Source={StaticResource Strings}}" ></ComboBoxItem>
                     <ComboBoxItem Tag="Pentagram" Content="{Binding XWDC_MarkerType_Pentagram, Source={StaticResource Strings}}" ></ComboBoxItem>
                     <ComboBoxItem Tag="Hexagram" Content="{Binding XWDC_MarkerType_Hexagram, Source={StaticResource Strings}}" ></ComboBoxItem>
+                    <ComboBoxItem Tag="Checkmark" Content="Checkmark" ></ComboBoxItem>
                     <ComboBoxItem Tag="Automatic" Content="{Binding XWDC_MarkerType_Automatic, Source={StaticResource Strings}}" ></ComboBoxItem>
                     <ComboBoxItem Tag="None" Content="{Binding XWDC_MarkerType_None, Source={StaticResource Strings}}" ></ComboBoxItem>
                 </ComboBox>

--- a/Examples/IGDataChart/Samples/Display/Markers/MarkerTypes.xaml
+++ b/Examples/IGDataChart/Samples/Display/Markers/MarkerTypes.xaml
@@ -90,6 +90,7 @@
                 <!-- ========================================================================== -->
                 <ig:SplineSeries Thickness="2"
                                  MarkerType="{Binding ElementName=cmbMarkerType, Path=SelectedItem.Tag, Converter={StaticResource MarkerTypeConverter}}"
+                                 MarkerSize="{Binding ElementName=markerSizeSlider, Path=Value}"
                                  ItemsSource="{StaticResource CategoryData}"
                                  ValueMemberPath="Value"
                                  XAxis="{Binding ElementName=categoryXAxis}"
@@ -117,6 +118,9 @@
                     <ComboBoxItem Tag="Automatic" Content="{Binding XWDC_MarkerType_Automatic, Source={StaticResource Strings}}" ></ComboBoxItem>
                     <ComboBoxItem Tag="None" Content="{Binding XWDC_MarkerType_None, Source={StaticResource Strings}}" ></ComboBoxItem>
                 </ComboBox>
+                <TextBlock Text="Marker Size" Style="{StaticResource SamplesInnerNavigationTitleStyle}" Margin="8,0,2,0"/>
+                <Slider x:Name="markerSizeSlider" Width="110" Minimum="6" Maximum="40" Value="20" TickFrequency="2" IsSnapToTickEnabled="True" VerticalAlignment="Center"/>
+                <TextBlock Text="{Binding ElementName=markerSizeSlider, Path=Value, StringFormat={}{0:0}}" VerticalAlignment="Center" Margin="4,0,2,0"/>
                 <Button x:Name="btnPrevious" HorizontalAlignment="Center" Cursor="Hand" Margin="0,0,2,0" Content="" Click="OnPrevButtonClick" Style="{StaticResource IGPreviousButtonStyle}" />
                 <Button x:Name="btnNext" HorizontalAlignment="Right" Cursor="Hand" Margin="0,0,2,0" Content="" Click="OnNextButtonClick" Style="{StaticResource IGNextButtonStyle}" />
             </StackPanel>

--- a/Examples/IGDataChart/Samples/Display/Markers/MarkerTypes.xaml
+++ b/Examples/IGDataChart/Samples/Display/Markers/MarkerTypes.xaml
@@ -30,43 +30,43 @@
             <!-- Default Marker Templates   -->
             <!-- ========================================================================== -->
             <DataTemplate x:Key="CircleMarkerTemplate">
-                <Ellipse Effect="{StaticResource MarkerEffect}" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="20" MinHeight="20" />
+                <Ellipse Effect="{StaticResource MarkerEffect}" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="10" MinHeight="10" />
             </DataTemplate>
 
             <DataTemplate x:Key="TriangleMarkerTemplate">
-                <Polygon Effect="{StaticResource MarkerEffect}" Points="0, 0 4, 8 8, 0" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="20" MinHeight="20" />
+                <Polygon Effect="{StaticResource MarkerEffect}" Points="0, 0 4, 8 8, 0" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="10" MinHeight="10" />
             </DataTemplate>
 
             <DataTemplate x:Key="PyramidMarkerTemplate">
-                <Polygon Effect="{StaticResource MarkerEffect}" Points="0, 8 4, 0 8, 8" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="20" MinHeight="20" />
+                <Polygon Effect="{StaticResource MarkerEffect}" Points="0, 8 4, 0 8, 8" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="10" MinHeight="10" />
             </DataTemplate>
 
             <DataTemplate x:Key="SquareMarkerTemplate">
-                <Rectangle Effect="{StaticResource MarkerEffect}" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="20" MinHeight="20" />
+                <Rectangle Effect="{StaticResource MarkerEffect}" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="10" MinHeight="10" />
             </DataTemplate>
 
             <DataTemplate x:Key="DiamondMarkerTemplate">
-                <Polygon Effect="{StaticResource MarkerEffect}" Points="0 4 4 8 8 4 4 0" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="20" MinHeight="20" />
+                <Polygon Effect="{StaticResource MarkerEffect}" Points="0 4 4 8 8 4 4 0" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="10" MinHeight="10" />
             </DataTemplate>
 
             <DataTemplate x:Key="PentagonMarkerTemplate">
-                <Polygon Effect="{StaticResource MarkerEffect}" Points="4 0 0.1956 2.764 1.65 7.236 6.35 7.236 7.8044 2.764" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="20" MinHeight="20" />
+                <Polygon Effect="{StaticResource MarkerEffect}" Points="4 0 0.1956 2.764 1.65 7.236 6.35 7.236 7.8044 2.764" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="10" MinHeight="10" />
             </DataTemplate>
 
             <DataTemplate x:Key="HexagonMarkerTemplate">
-                <Polygon Effect="{StaticResource MarkerEffect}" Points="4 0 0.536 2 0.536 6 4 8 7.464 6 7.464 2" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="20" MinHeight="20" />
+                <Polygon Effect="{StaticResource MarkerEffect}" Points="4 0 0.536 2 0.536 6 4 8 7.464 6 7.464 2" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="10" MinHeight="10" />
             </DataTemplate>
 
             <DataTemplate x:Key="TetragramMarkerTemplate">
-                <Polygon Effect="{StaticResource MarkerEffect}" Points="4 0 2.5856 2.5856 0 4 2.5856 5.4144 4 8 5.4144 5.4144 8 4 5.4144 2.5856" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="20" MinHeight="20" />
+                <Polygon Effect="{StaticResource MarkerEffect}" Points="4 0 2.5856 2.5856 0 4 2.5856 5.4144 4 8 5.4144 5.4144 8 4 5.4144 2.5856" Stretch="Fill" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="10" MinHeight="10" />
             </DataTemplate>
 
             <DataTemplate x:Key="PentagramMarkerTemplate">
-                <Polygon Effect="{StaticResource MarkerEffect}" Points="4 0 2.8244 2.382 0.1956 2.764 2.098 4.618 1.6488 7.236 4 6 6.3512 7.236 5.902 4.618 7.8044 2.764 5.1756 2.382" Margin="-2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Stretch="Fill" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="20" MinHeight="20" />
+                <Polygon Effect="{StaticResource MarkerEffect}" Points="4 0 2.8244 2.382 0.1956 2.764 2.098 4.618 1.6488 7.236 4 6 6.3512 7.236 5.902 4.618 7.8044 2.764 5.1756 2.382" Margin="-2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Stretch="Fill" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="10" MinHeight="10" />
             </DataTemplate>
 
             <DataTemplate x:Key="HexagramMarkerTemplate">
-                <Polygon Effect="{StaticResource MarkerEffect}" Points="4 0 3 2.268 0.536 2 2 4 0.536 6 3 5.732 4 8 5 5.732 7.464 6 6 4 7.464 2 5 2.268" Stretch="Fill" Margin="-2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="20" MinHeight="20" />
+                <Polygon Effect="{StaticResource MarkerEffect}" Points="4 0 3 2.268 0.536 2 2 4 0.536 6 3 5.732 4 8 5 5.732 7.464 6 6 4 7.464 2 5 2.268" Stretch="Fill" Margin="-2" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Fill="{Binding ActualItemBrush}" Stroke="{Binding Series.ActualMarkerOutline}" StrokeThickness="2" MinWidth="10" MinHeight="10" />
             </DataTemplate>
             <!-- #END SNIPPET# -->
             <!-- ========================================================================== -->
@@ -119,7 +119,7 @@
                     <ComboBoxItem Tag="None" Content="{Binding XWDC_MarkerType_None, Source={StaticResource Strings}}" ></ComboBoxItem>
                 </ComboBox>
                 <TextBlock Text="Marker Size" Style="{StaticResource SamplesInnerNavigationTitleStyle}" Margin="8,0,2,0"/>
-                <Slider x:Name="markerSizeSlider" Width="110" Minimum="6" Maximum="40" Value="20" TickFrequency="2" IsSnapToTickEnabled="True" VerticalAlignment="Center"/>
+                <Slider x:Name="markerSizeSlider" Width="110" Minimum="10" Maximum="40" Value="20" TickFrequency="2" IsSnapToTickEnabled="True" VerticalAlignment="Center"/>
                 <TextBlock Text="{Binding ElementName=markerSizeSlider, Path=Value, StringFormat={}{0:0}}" VerticalAlignment="Center" Margin="4,0,2,0"/>
                 <Button x:Name="btnPrevious" HorizontalAlignment="Center" Cursor="Hand" Margin="0,0,2,0" Content="" Click="OnPrevButtonClick" Style="{StaticResource IGPreviousButtonStyle}" />
                 <Button x:Name="btnNext" HorizontalAlignment="Right" Cursor="Hand" Margin="0,0,2,0" Content="" Click="OnNextButtonClick" Style="{StaticResource IGNextButtonStyle}" />


### PR DESCRIPTION
Agent-Logs-Url: https://github.com/Infragistics/wpf-samples/sessions/81bf0a77-519c-4b5e-b9d2-bcc20fb5c82b  
More details in wrongly targeted <a href="https://github.com/Infragistics/wpf-samples/pull/95">PR</a>

Updated based on feedback to also add a **Checkmark** option to the Marker Type dropdowns in the IGDataChart marker samples (`MarkerTypes.xaml` and `BubbleMarkers.xaml`).